### PR TITLE
Changes to dupe detection for xBridge with queue, make GATT close on BLE disconnect optional

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1551,6 +1551,8 @@ public class Home extends ActivityWithMenu {
 
 
             }
+        } else {
+            dexbridgeBattery.setVisibility(View.INVISIBLE);
         }
         if (!prefs.getBoolean("display_bridge_battery", true)) {
             dexbridgeBattery.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1551,8 +1551,6 @@ public class Home extends ActivityWithMenu {
 
 
             }
-        } else {
-            dexbridgeBattery.setVisibility(View.INVISIBLE);
         }
         if (!prefs.getBoolean("display_bridge_battery", true)) {
             dexbridgeBattery.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -347,16 +347,6 @@ public class BgReading extends Model implements ShareUploadableBg{
             return bgReading;
         }
 
-        final List<BgReading> possibleDuplicates = possibleDuplicates(timestamp);
-            if (possibleDuplicates != null && possibleDuplicates.size() > 0) {
-                Log.i(TAG, "BgReading.create: Received Packet where we already have another reading for the same timeslot. Exiting.");
-                final DateFormat dateFormatter = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.getDefault());
-                for (BgReading reading : possibleDuplicates) {
-                    Log.i(TAG, "  Possible duplicate with offset " + (timestamp - reading.timestamp) + " ms to reading at " + dateFormatter.format(new Date(reading.timestamp)) + ", raw: " + (raw_data/1000) + " vs. " + reading.raw_data + ".");
-                }
-            return null;
-        }
-
         Calibration calibration = Calibration.lastValid();
         if (calibration == null) {
             Log.d(TAG, "create: No calibration yet");
@@ -587,23 +577,6 @@ public class BgReading extends Model implements ShareUploadableBg{
                         .orderBy("timestamp desc")
                         .executeSingle();
             }
-        }
-        return null;
-    }
-
-    // TODO this method and readingNearTimeStamp should probably get merged in to a single method with margin as a parameter
-    public static List<BgReading> possibleDuplicates(long timestamp) {
-        final Sensor sensor = Sensor.currentSensor();
-        if (sensor != null) {
-            return new Select()
-                    .from(BgReading.class)
-                    .where("Sensor = ? ", sensor.getId())
-                    .where("calculated_value != 0")
-                    .where("raw_data != 0")
-                    .where("timestamp >= " + (timestamp-(3*60*1000))) // if we already have a reading up to 3 minutes before that timestamp
-                    .where("timestamp <= " + (timestamp+(3*60*1000))) // or there is within 3 minutes after the given timestamp
-                    .orderBy("timestamp desc")
-                    .execute();
         }
         return null;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
@@ -69,9 +69,17 @@ public class TransmitterData extends Model {
             transmitterData.filtered_data = Integer.parseInt(data[0]);
             transmitterData.timestamp = timestamp;
         }
-        //Stop allowing duplicate data, its bad!
-        TransmitterData lastTransmitterData = TransmitterData.last();
+
+        //Stop allowing readings that are older than the last one - or duplicate data, its bad!
+        final TransmitterData lastTransmitterData = TransmitterData.last();
+        if (lastTransmitterData != null && lastTransmitterData.timestamp >= timestamp) {
+            return null;
+        }
         if (lastTransmitterData != null && lastTransmitterData.raw_data == transmitterData.raw_data && Math.abs(lastTransmitterData.timestamp - timestamp) < (120000)) {
+            return null;
+        }
+        final Calibration lastCalibration = Calibration.last();
+        if (lastCalibration != null && lastCalibration.timestamp > timestamp) {
             return null;
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -285,13 +285,15 @@ public class DexCollectionService extends Service {
                     case BluetoothProfile.STATE_DISCONNECTED:
                         mConnectionState = STATE_DISCONNECTED;
                         ActiveBluetoothDevice.disconnected();
-                        if (mBluetoothGatt != null) {
-                            Log.i(TAG, "onConnectionStateChange: mBluetoothGatt is not null, closing.");
-                            mBluetoothGatt.close();
-                            mBluetoothGatt = null;
-                            mCharacteristic = null;
+                        if (prefs.getBoolean("close_gatt_on_ble_disconnect", true)) {
+                            if (mBluetoothGatt != null) {
+                                Log.i(TAG, "onConnectionStateChange: mBluetoothGatt is not null, closing.");
+                                mBluetoothGatt.close();
+                                mBluetoothGatt = null;
+                                mCharacteristic = null;
+                            }
+                            lastdata = null;
                         }
-                        lastdata = null;
                         Log.i(TAG, "onConnectionStateChange: Disconnected from GATT server.");
                         setRetryTimer();
                         break;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -656,6 +656,8 @@ public class Preferences extends PreferenceActivity {
 
             final Preference scanShare = findPreference("scan_share2_barcode");
             final EditTextPreference transmitterId = (EditTextPreference) findPreference("dex_txid");
+            final Preference closeGatt = findPreference("close_gatt_on_ble_disconnect");
+
             final Preference pebbleSync2 = findPreference("broadcast_to_pebble_type");
             final Preference pebbleSync1 = findPreference("broadcast_to_pebble");
 
@@ -839,6 +841,7 @@ public class Preferences extends PreferenceActivity {
             if ((collectionType != DexCollectionType.DexbridgeWixel)
                     && (collectionType != DexCollectionType.WifiDexBridgeWixel)) {
                 collectionCategory.removePreference(transmitterId);
+                collectionCategory.removePreference(closeGatt);
             }
 
             // shouldn't this be merged in to logic above?
@@ -1119,10 +1122,11 @@ public class Preferences extends PreferenceActivity {
                     if ((collectionType != DexCollectionType.DexbridgeWixel)
                             && (collectionType != DexCollectionType.WifiDexBridgeWixel)) {
                         collectionCategory.removePreference(transmitterId);
-
+                        collectionCategory.removePreference(closeGatt);
                         //TODO Bridge battery display support
                     } else {
                         collectionCategory.addPreference(transmitterId);
+                        collectionCategory.addPreference(closeGatt);
                     }
 
                     if (collectionType == DexCollectionType.DexcomG5) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -397,6 +397,7 @@
     <string name="compatible_broadcast">Compatible Broadcast</string>
     <string name="show_datatables">Show Datatables</string>
     <string name="display_bridge_battery">Display Bridge Battery</string>
+    <string name="close_gatt_on_ble_disconnect">Close GATT on BLE disconnect</string>
     <string name="disable_battery_warning">Disable Battery Warning</string>
     <string name="additional_text_status">Additional text status</string>
     <string name="average">Average</string>

--- a/app/src/main/res/xml/pref_data_source.xml
+++ b/app/src/main/res/xml/pref_data_source.xml
@@ -33,6 +33,13 @@
             android:defaultValue="ABCDEF" />
 
         <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="close_gatt_on_ble_disconnect"
+            android:summary="Close GATT on BLE disconnect"
+            android:title="@string/close_gatt_on_ble_disconnect" />
+
+
+        <CheckBoxPreference
             android:key="run_service_in_foreground"
             android:title="@string/run_collector_in_foreground"
             android:summary="@string/shows_a_persistent_notification"


### PR DESCRIPTION
Dupe detection changed to only allow a chronological order of transmittervalues (due to discussion with xDrip-E folks), made GATT close on BLE disconnect an option (works better without in my case)