### PR TITLE
gregorybel/Missed reading timeout increase to 6min

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
@@ -152,9 +152,9 @@ public class MissedReadingService extends IntentService {
     
     // alarmIn is relative time ms
     public void setAlarm(long alarmIn, boolean force) {
-        if(!force && (alarmIn < 5 * 60 * 1000)) {
-            // No need to check more than once every 5 minutes
-            alarmIn = 5 * 60 * 1000;
+        if(!force && (alarmIn < 6 * 60 * 1000)) {
+            // No need to check more than once every 6 minutes as most CGM wake-up every 5min
+            alarmIn = 6 * 60 * 1000;
         }
 
         alarmIn = Math.max(alarmIn, 5000); // don't try to set less than 5 seconds in the future

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Blukon.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Blukon.java
@@ -91,6 +91,8 @@ public class Blukon {
             }
         }
 
+        Log.w(TAG,"isCollecting() returns: " + m_communicationStarted);
+
         return m_communicationStarted;
     }
 
@@ -99,7 +101,7 @@ public class Blukon {
     }
 
     public static void initialize() {
-            Log.i(TAG, "initialize!");
+            Log.w(TAG, "initialize Blukon!");
             Pref.setInt("bridge_battery", 0); //force battery to no-value before first reading
             Pref.setInt("nfc_sensor_age", 0); //force sensor age to no-value before first reading
             JoH.clearRatelimit(BLUKON_GETSENSORAGE_TIMER);


### PR DESCRIPTION
As most CGM wake-up every 5min, restarting service every 6min should be enough.
It may prevent race condition during restart and collecting.
Successfully tested.