### PR TITLE
Checkbox to force speaker output on alarm when headphones are connected.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <uses-permission-sdk-23 android:name="android.permission.CAMERA" />
     <uses-permission-sdk-23 android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -95,6 +95,7 @@ public class EditAlertActivity extends ActivityWithMenu {
     private LinearLayout layoutSilentModeWarning;
     private TextView viewAlertOverrideText;
     private CheckBox checkboxOverrideSilent;
+    private CheckBox checkboxForceSpeaker;
     private boolean doMgdl;
 
     private String uuid;
@@ -171,6 +172,7 @@ public class EditAlertActivity extends ActivityWithMenu {
         layoutSilentModeWarning = (LinearLayout) findViewById(R.id.layout_silent_mode_warning);
         viewAlertOverrideText = (TextView) findViewById(R.id.view_alert_override_silent);
         checkboxOverrideSilent = (CheckBox) findViewById(R.id.check_override_silent);
+        checkboxForceSpeaker = (CheckBox) findViewById(R.id.check_force_speaker);
         this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
         addListenerOnButtons();
 
@@ -225,6 +227,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             checkboxVibrate.setChecked(true);
             checkboxDisabled.setChecked(false);
             checkboxOverrideSilent.setChecked(true);
+            checkboxForceSpeaker.setChecked(true);
 
             audioPath = "";
             alertMp3File.setText(shortPath(audioPath));
@@ -257,6 +260,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             checkboxVibrate.setChecked(alertType.vibrate);
             checkboxDisabled.setChecked(!alertType.active);
             checkboxOverrideSilent.setChecked(alertType.override_silent_mode);
+            checkboxForceSpeaker.setChecked(alertType.force_speaker);
             defaultSnooze = alertType.default_snooze;
             if(defaultSnooze == 0) {
                 SnoozeActivity.getDefaultSnooze(above);
@@ -280,6 +284,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                 checkboxAllDay.setEnabled(false);
                 checkboxVibrate.setEnabled(false);
                 checkboxOverrideSilent.setEnabled(false);
+                checkboxForceSpeaker.setEnabled(false);
                 reraise.setEnabled(false);
             }
         }
@@ -537,12 +542,13 @@ public class EditAlertActivity extends ActivityWithMenu {
                 boolean vibrate = checkboxVibrate.isChecked();
                 
                 boolean overrideSilentMode = checkboxOverrideSilent.isChecked();
+                boolean forceSpeaker = checkboxForceSpeaker.isChecked();
 
                 String mp3_file = audioPath;
                 if (uuid != null) {
-                    AlertType.update_alert(uuid, alertText.getText().toString(), above, threshold, allDay, alertReraise, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze, vibrate, !disabled);
+                    AlertType.update_alert(uuid, alertText.getText().toString(), above, threshold, allDay, alertReraise, mp3_file, timeStart, timeEnd, overrideSilentMode, forceSpeaker, defaultSnooze, vibrate, !disabled);
                 }  else {
-                    AlertType.add_alert(null, alertText.getText().toString(), above, threshold, allDay, alertReraise, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze, vibrate, !disabled);
+                    AlertType.add_alert(null, alertText.getText().toString(), above, threshold, allDay, alertReraise, mp3_file, timeStart, timeEnd, overrideSilentMode, forceSpeaker, defaultSnooze, vibrate, !disabled);
                 }
 
                 startWatchUpdaterService(mContext, WatchUpdaterService.ACTION_SYNC_ALERTTYPE, TAG);
@@ -765,17 +771,11 @@ public class EditAlertActivity extends ActivityWithMenu {
     }
 
     public static boolean isPathRingtone(Context context, String path) {
-        if(path == null) {
-            return false;
-        }
-        if(path.length() == 0) {
+        if (path == null || path.isEmpty()) {
             return false;
         }
         Ringtone ringtone = RingtoneManager.getRingtone(context, Uri.parse(path));
-        if(ringtone == null) {
-            return false;
-        }
-        return true;
+        return ringtone != null;
     }
 
     public String shortPath(String path) {
@@ -927,6 +927,7 @@ public class EditAlertActivity extends ActivityWithMenu {
         }
         boolean vibrate = checkboxVibrate.isChecked();
         boolean overrideSilentMode = checkboxOverrideSilent.isChecked();
+        boolean forceSpeaker = checkboxForceSpeaker.isChecked();
         String mp3_file = audioPath;
         try {
             int defaultSnooze = safeGetDefaultSnooze();
@@ -939,7 +940,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                 JoH.static_toast_long("Volume Profile is set to silent!");
             }
 
-            AlertType.testAlert(alertText.getText().toString(), above, threshold, allDay, 1, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze, vibrate, mContext);
+            AlertType.testAlert(alertText.getText().toString(), above, threshold, allDay, 1, mp3_file, timeStart, timeEnd, overrideSilentMode, forceSpeaker, defaultSnooze, vibrate, mContext);
         } catch (NullPointerException e) {
             JoH.static_toast_long("Snooze value is not a number - cannot test");
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/AlertType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/AlertType.java
@@ -62,6 +62,10 @@ public class AlertType extends Model {
     public boolean override_silent_mode;
 
     @Expose
+    @Column(name = "force_speaker")
+    public boolean force_speaker;
+
+    @Expose
     @Column(name = "predictive")
     public boolean predictive;
 
@@ -124,6 +128,7 @@ public class AlertType extends Model {
                 "ALTER TABLE AlertType ADD COLUMN light INTEGER;",
                 "ALTER TABLE AlertType ADD COLUMN predictive INTEGER;",
                 "ALTER TABLE AlertType ADD COLUMN text TEXT;",
+                "ALTER TABLE AlertType ADD COLUMN force_speaker INTEGER;",
                 "ALTER TABLE AlertType ADD COLUMN time_until_threshold_crossed REAL;"
               };
 
@@ -292,6 +297,7 @@ public class AlertType extends Model {
             int start_time_minutes,
             int end_time_minutes,
             boolean override_silent_mode,
+            boolean force_speaker,
             int snooze,
             boolean vibrate,
             boolean active) {
@@ -307,6 +313,7 @@ public class AlertType extends Model {
         at.start_time_minutes = start_time_minutes;
         at.end_time_minutes = end_time_minutes;
         at.override_silent_mode = override_silent_mode;
+        at.force_speaker = force_speaker;
         at.default_snooze = snooze;
         at.vibrate = vibrate;
         at.save();
@@ -323,6 +330,7 @@ public class AlertType extends Model {
             int start_time_minutes,
             int end_time_minutes,
             boolean override_silent_mode,
+            boolean force_speaker,
             int snooze,
             boolean vibrate,
             boolean active) {
@@ -345,6 +353,7 @@ public class AlertType extends Model {
         at.start_time_minutes = start_time_minutes;
         at.end_time_minutes = end_time_minutes;
         at.override_silent_mode = override_silent_mode;
+        at.force_speaker = force_speaker;
         at.default_snooze = snooze;
         at.vibrate = vibrate;
         at.save();
@@ -431,16 +440,16 @@ public class AlertType extends Model {
     // This alert will not be editable/removable.
     public static void CreateStaticAlerts() {
         if(get_alert(LOW_ALERT_55) == null) {
-            add_alert(LOW_ALERT_55, "low alert ", false, 55, true, 1, null, 0, 0, true, 20, true, true);
+            add_alert(LOW_ALERT_55, "low alert ", false, 55, true, 1, null, 0, 0, true, true, 20, true, true);
         }
     }
 
 
     public static void testAll(Context context) {
         remove_all();
-        add_alert(null, "high alert 1", true, 180, true, 10, null, 0, 0, true, 20, true, true);
-        add_alert(null, "high alert 2", true, 200, true, 10, null, 0, 0, true, 20, true, true);
-        add_alert(null, "high alert 3", true, 220, true, 10, null, 0, 0, true, 20, true, true);
+        add_alert(null, "high alert 1", true, 180, true, 10, null, 0, 0, true, true, 20, true, true);
+        add_alert(null, "high alert 2", true, 200, true, 10, null, 0, 0, true, true,20, true, true);
+        add_alert(null, "high alert 3", true, 220, true, 10, null, 0, 0, true, true,20, true, true);
         print_all();
         AlertType a1 = get_highest_active_alert(context, 190);
         Log.d(TAG, "a1 = " + a1.toString());
@@ -451,8 +460,8 @@ public class AlertType extends Model {
         AlertType a3 = get_alert(a1.uuid);
         Log.d(TAG, "a1 == a3 ? need to see true " + (a1==a3) + a1 + " " + a3);
 
-        add_alert(null, "low alert 1", false, 80, true, 10, null, 0, 0, true, 20, true, true);
-        add_alert(null, "low alert 2", false, 60, true, 10, null, 0, 0, true, 20, true, true);
+        add_alert(null, "low alert 1", false, 80, true, 10, null, 0, 0, true, true,20, true, true);
+        add_alert(null, "low alert 2", false, 60, true, 10, null, 0, 0, true, true,20, true, true);
 
         AlertType al1 = get_highest_active_alert(context, 90);
         Log.d(TAG, "al1 should be null  " + al1);
@@ -545,6 +554,7 @@ public class AlertType extends Model {
         int start_time_minutes,
         int end_time_minutes,
         boolean override_silent_mode,
+        boolean force_speaker,
         int snooze,
         boolean vibrate,
         Context context) {
@@ -560,6 +570,7 @@ public class AlertType extends Model {
             at.start_time_minutes = start_time_minutes;
             at.end_time_minutes = end_time_minutes;
             at.override_silent_mode = override_silent_mode;
+            at.force_speaker = force_speaker;
             at.default_snooze = snooze;
             at.vibrate = vibrate;
             AlertPlayer.getPlayer().startAlert(context, false, at, "TEST", false);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -15,7 +15,6 @@ import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 
-import com.eveningoutpost.dexdrip.EditAlertActivity;
 import com.eveningoutpost.dexdrip.GcmActivity;
 import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.Models.ActiveBgAlert;
@@ -37,7 +36,6 @@ import java.io.IOException;
 import java.util.Date;
 
 import static com.eveningoutpost.dexdrip.Home.startWatchUpdaterService;
-import static com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer.getAlertPlayerStreamType;
 
 // A helper class to create the mediaplayer on the UI thread.
 // This is needed in order for the callbackst to work.
@@ -81,17 +79,11 @@ class MediaPlayerCreaterHelper {
             synchronized(creationThreadLock) {
                 // TODO thread deadlock possible here?
                 while(mplayerCreated_ == false) {
-                   
-                        creationThreadLock.wait(30 * Constants.SECOND_IN_MS);
+                    creationThreadLock.wait(30 * Constants.SECOND_IN_MS);
                 }
             } 
         }catch (InterruptedException e){
              Log.e(TAG, "Cought exception", e);
-        }
-        try {
-            mediaPlayer_.setAudioStreamType(getAlertPlayerStreamType());
-        } catch (Exception e) {
-            UserError.Log.e(TAG, "Set mediaplayer stream type: " + e);
         }
         return mediaPlayer_;
     }
@@ -120,6 +112,7 @@ public class AlertPlayer {
     final static int MAX_VIBRATING_MINUTES = 2;
     final static int MAX_ASCENDING_MINUTES = 5;
 
+    public int streamType = AudioManager.STREAM_MUSIC;
 
     public static synchronized AlertPlayer getPlayer() {
         if(alertPlayerInstance == null) {
@@ -151,7 +144,7 @@ public class AlertPlayer {
         long nextAlertTime = newAlert.getNextAlertTime(ctx);
 
         ActiveBgAlert.Create(newAlert.uuid, start_snoozed, nextAlertTime);
-        if (!start_snoozed) VibrateNotifyMakeNoise(ctx, newAlert, bgValue, newAlert.override_silent_mode, 0);
+        if (!start_snoozed) VibrateNotifyMakeNoise(ctx, newAlert, bgValue, 0);
         AlertTracker.evaluate();
     }
 
@@ -176,7 +169,6 @@ public class AlertPlayer {
             mediaPlayer.release();
             mediaPlayer = null;
         }
-        revertCurrentVolume(ctx);
     }
 
     // only do something if an alert is active - only call from interactive
@@ -227,7 +219,7 @@ public class AlertPlayer {
         if (from_interactive) GcmActivity.sendSnoozeToRemote();
     }
 
-    public synchronized  void PreSnooze(Context ctx, String uuid, int repeatTime) {
+    public synchronized void PreSnooze(Context ctx, String uuid, int repeatTime) {
         Log.i(TAG, "PreSnooze called repeatTime = "+ repeatTime);
         stopAlert(ctx, true, false);
         ActiveBgAlert.Create(uuid, true, new Date().getTime() + repeatTime * 60000);
@@ -238,14 +230,6 @@ public class AlertPlayer {
         }
         activeBgAlert.snooze(repeatTime);
     }
-
-    public static int getAlertPlayerStreamType() {
-       // return AudioManager.STREAM_ALARM;
-        // FUTURE this could be from preference setting or follow override silent boolean
-        // FUTURE audio attributes can be supported in later android versions
-        return AudioManager.STREAM_MUSIC;
-    }
-
 
     // Check the state and alrarm if needed
     public void ClockTick(Context ctx, boolean trendingToAlertEnd, String bgValue)
@@ -273,7 +257,7 @@ public class AlertPlayer {
             long nextAlertTime = alert.getNextAlertTime(ctx);
             activeBgAlert.updateNextAlertAt(nextAlertTime);
             
-            VibrateNotifyMakeNoise(ctx, alert, bgValue, alert.override_silent_mode, minutesFromStartPlaying);
+            VibrateNotifyMakeNoise(ctx, alert, bgValue, minutesFromStartPlaying);
             AlertTracker.evaluate();
         }
 
@@ -308,11 +292,11 @@ public class AlertPlayer {
         return false;
     }
 
-    private synchronized void PlayFile(final Context ctx, String FileName, float VolumeFrac) {
-        Log.i(TAG, "PlayFile: called FileName = " + FileName);
+    private synchronized void playFile(final Context ctx, String fileName, float volumeFrac, boolean forceSpeaker) {
+        Log.i(TAG, "playFile: called fileName = " + fileName);
 
-        if(mediaPlayer != null) {
-            Log.i(TAG, "ERROR, PlayFile:going to leak a mediaplayer !!!");
+        if (mediaPlayer != null) {
+            Log.i(TAG, "ERROR, playFile:going to leak a mediaplayer !!!");
             mediaPlayer.release();
             mediaPlayer = null;
         }
@@ -324,8 +308,8 @@ public class AlertPlayer {
         }
         
         boolean setDataSourceSucceeded = false;
-        if(FileName != null && FileName.length() > 0) {
-            setDataSourceSucceeded = setMediaDataSource(ctx, mediaPlayer, Uri.parse(FileName));
+        if(fileName != null && fileName.length() > 0) {
+            setDataSourceSucceeded = setMediaDataSource(ctx, mediaPlayer, Uri.parse(fileName));
         }
         if (setDataSourceSucceeded == false) {
             setDataSourceSucceeded = setMediaDataSource(ctx, mediaPlayer, R.raw.default_alert);
@@ -334,62 +318,60 @@ public class AlertPlayer {
             Log.e(TAG, "setMediaDataSource failed");
             return;
         }
-            
+
+        int streamType = forceSpeaker ? AudioManager.STREAM_ALARM : AudioManager.STREAM_MUSIC;
+
         try {
-            mediaPlayer.prepare();
-        } catch (IllegalStateException | IOException e) {
-            Log.e(TAG, "Caught exception preparing mediaPlayer", e);
-            return;
-        } catch (NullPointerException e) {
-            Log.e(TAG,"Possible deep error in mediaPlayer", e);
-        }
-
-        if (mediaPlayer != null) {
-            AudioManager manager = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
-            int maxVolume = manager.getStreamMaxVolume(getAlertPlayerStreamType());
-            volumeBeforeAlert = manager.getStreamVolume(getAlertPlayerStreamType());
-            volumeForThisAlert = (int) (maxVolume * VolumeFrac);
-
-            Log.i(TAG, "before playing volumeBeforeAlert " + volumeBeforeAlert + " volumeForThisAlert " + volumeForThisAlert);
-            try {
-                manager.setStreamVolume(getAlertPlayerStreamType(), volumeForThisAlert, 0);
-            } catch (SecurityException e) {
-                if (JoH.ratelimit("sound volume error", 12000)) {
-                    UserError.Log.wtf(TAG, "This device does not allow us to modify the sound volume");
-                }
-            }
-            try {
-                mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-                    @Override
-                    public void onCompletion(MediaPlayer mp) {
-                        Log.i(TAG, "PlayFile: onCompletion called (finished playing) ");
-                        revertCurrentVolume(ctx);
-                    }
-                });
-                Log.i(TAG, "PlayFile: calling mediaPlayer.start() ");
+            mediaPlayer.setAudioStreamType(streamType);
+            mediaPlayer.setOnPreparedListener(mp -> {
+                Log.i(TAG, "playFile: calling mediaPlayer.start() ");
+                adjustCurrentVolumeForAlert(ctx, streamType, volumeFrac);
                 mediaPlayer.start();
-            } catch (NullPointerException e) {
-                Log.wtf(TAG, "Playfile: Concurrency related null pointer exception: " + e.toString());
-            } catch (IllegalStateException e) {
-                Log.wtf(TAG, "Playfile: Concurrency related illegal state exception: " + e.toString());
-            }
+            });
 
-        } else {
-            // TODO, what should we do here???
-            Log.wtf(TAG, "PlayFile: Starting an alert failed, what should we do !!!");
+            mediaPlayer.setOnCompletionListener(mp -> {
+                Log.i(TAG, "playFile: onCompletion called (finished playing) ");
+                mediaPlayer.stop();
+                mediaPlayer.release();
+                mediaPlayer = null;
+                revertCurrentVolume(ctx, streamType);
+            });
+
+            mediaPlayer.prepareAsync();
+        } catch (NullPointerException e) {
+            Log.wtf(TAG, "Playfile: Concurrency related null pointer exception: " + e.toString());
+        } catch (IllegalStateException e) {
+            Log.wtf(TAG, "Playfile: Concurrency related illegal state exception: " + e.toString());
         }
     }
 
-    private synchronized void revertCurrentVolume(final Context ctx) {
+    private void adjustCurrentVolumeForAlert(Context ctx, int streamType, float volumeFrac) {
         AudioManager manager = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
-        int currentVolume = manager.getStreamVolume(getAlertPlayerStreamType());
+        int maxVolume = manager.getStreamMaxVolume(streamType);
+        volumeBeforeAlert = manager.getStreamVolume(streamType);
+        volumeForThisAlert = (int) (maxVolume * volumeFrac);
+        Log.i(TAG, "before playing volumeBeforeAlert " + volumeBeforeAlert + " volumeForThisAlert " + volumeForThisAlert);
+        try {
+            if (volumeBeforeAlert <= 0) {
+                manager.setStreamVolume(streamType, volumeForThisAlert, 0);
+            }
+        } catch (SecurityException e) {
+            if (JoH.ratelimit("sound volume error", 12000)) {
+                UserError.Log.wtf(TAG, "This device does not allow us to modify the sound volume");
+            }
+        }
+    }
+
+    private synchronized void revertCurrentVolume(final Context ctx, final int streamType) {
+        AudioManager manager = (AudioManager) ctx.getSystemService(Context.AUDIO_SERVICE);
+        int currentVolume = manager.getStreamVolume(streamType);
         Log.i(TAG, "revertCurrentVolume volumeBeforeAlert " + volumeBeforeAlert + " volumeForThisAlert " + volumeForThisAlert
                 + " currentVolume " + currentVolume);
         if (volumeForThisAlert == currentVolume && (volumeBeforeAlert != -1) && (volumeForThisAlert != -1)) {
             // If the user has changed the volume, don't change it again.
 
             try {
-                manager.setStreamVolume(getAlertPlayerStreamType(), volumeBeforeAlert, 0);
+                manager.setStreamVolume(streamType, volumeBeforeAlert, 0);
             } catch (SecurityException e) {
                 if (JoH.ratelimit("sound volume error", 12000)) {
                     UserError.Log.wtf(TAG, "This device does not allow us to modify the sound volume");
@@ -451,7 +433,7 @@ public class AlertPlayer {
         return !(Pref.getBooleanDefaultFalse("no_alarms_during_calls") && (JoH.isOngoingCall()));
     }
 
-    private void VibrateNotifyMakeNoise(Context context, AlertType alert, String bgValue, Boolean overrideSilent, int minsFromStartPlaying) {
+    private void VibrateNotifyMakeNoise(Context context, AlertType alert, String bgValue, int minsFromStartPlaying) {
         Log.d(TAG, "VibrateNotifyMakeNoise called minsFromStartedPlaying = " + minsFromStartPlaying);
         Log.d("ALARM", "setting vibrate alarm");
         int profile = getAlertProfile(context);
@@ -478,6 +460,7 @@ public class AlertPlayer {
                 .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
                 .setContentTitle(title)
                 .setContentText(content)
+                //.addAction(R.drawable.ic_action_communication_invert_colors_on, "SNOOZE", notificationIntent(context, intent))
                 .setContentIntent(notificationIntent(context, intent))
                 .setLocalOnly(localOnly)
                 .setPriority(Pref.getBooleanDefaultFalse("high_priority_notifications") ? Notification.PRIORITY_MAX : Notification.PRIORITY_HIGH)
@@ -492,15 +475,11 @@ public class AlertPlayer {
                     volumeFrac = (float) 0.7;
                 }
                 Log.d(TAG, "VibrateNotifyMakeNoise volumeFrac = " + volumeFrac);
-                boolean isRingTone = EditAlertActivity.isPathRingtone(context, alert.mp3_file);
-
+                boolean overrideSilent = alert.override_silent_mode;
+                boolean forceSpeaker = alert.force_speaker;
                 if (notSilencedDueToCall()) {
-                    if (isRingTone && !overrideSilent) {
-                        builder.setSound(Uri.parse(alert.mp3_file));
-                    } else {
-                        if (overrideSilent || isLoudPhone(context)) {
-                            PlayFile(context, alert.mp3_file, volumeFrac);
-                        }
+                    if (overrideSilent || isLoudPhone(context)) {
+                        playFile(context, alert.mp3_file, volumeFrac, forceSpeaker);
                     }
                 } else {
                     Log.i(TAG, "Silenced Alert Noise due to ongoing call");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/IdempotentMigrations.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/IdempotentMigrations.java
@@ -67,8 +67,8 @@ public class IdempotentMigrations {
             int bg_low_snooze = Integer.parseInt(prefs.getString("bg_snooze",  Integer.toString(SnoozeActivity.getDefaultSnooze(false))));
 
 
-            AlertType.add_alert(null, mContext.getString(R.string.high_alert), true, highMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, bg_high_snooze, true, true);
-            AlertType.add_alert(null, mContext.getString(R.string.low_alert), false, lowMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, bg_low_snooze, true, true);
+            AlertType.add_alert(null, mContext.getString(R.string.high_alert), true, highMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, false, bg_high_snooze, true, true);
+            AlertType.add_alert(null, mContext.getString(R.string.low_alert), false, lowMark, true, 1, bg_notification_sound, 0, 0, bg_sound_in_silent, false, bg_low_snooze, true, true);
             prefs.edit().putBoolean("bg_notifications", false).apply();
         }
     }

--- a/app/src/main/res/layout/activity_edit_alert.xml
+++ b/app/src/main/res/layout/activity_edit_alert.xml
@@ -327,6 +327,37 @@
                     <LinearLayout
                         android:orientation="horizontal"
                         android:layout_width="fill_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:paddingTop="20dp"
+                        >
+
+                        <TextView
+                            android:id="@+id/view_alert_force_speaker"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/force_speaker_colon"
+                            android:textSize="15sp"
+                            android:gravity="left"
+                            android:layout_centerVertical="true"
+                            android:layout_weight="1"
+                            />
+
+                        <CheckBox
+                            android:id="@+id/check_force_speaker"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text=""
+                            android:textSize="15sp"
+                            android:gravity="right"
+                            android:layout_centerVertical="true"
+                            android:layout_weight="0" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="fill_parent"
                         android:layout_height="wrap_content"
                         android:gravity="center_vertical"
                         android:paddingTop="10dp">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1142,6 +1142,7 @@
     <string name="please_allow_permission">Please Allow Permission</string>
     <string name="without_location_scan_doesnt_work">Without Location permission Android Bluetooth scan doesn\'t work</string>
     <string name="without_location_permission_emergency_cannot_get_location">Without Location permission emergency messages cannot use location data</string>
+    <string name="force_speaker_colon">Force Speaker</string>
     <string name="choose_data_source">Choose Data Source</string>
     <string name="which_system_do_you_use">Which system do you use?</string>
 


### PR DESCRIPTION
Hi, I've added a checkbox to the edit alert page that, when checked, forces the alert output to the speakers of the phone. The usecase for this change was that I didn't hear the alert at night when I forgot to pull out my headphones. To me, bg alerts at night should behave like alarm clock alerts.

This behaviour is implemented by changing the stream type to STREAM_ALARM.