### PR TITLE
Request exclusive audiofocus during alerts.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -346,6 +346,9 @@ public class AlertPlayer {
         streamType = forceSpeaker ? AudioManager.STREAM_ALARM : AudioManager.STREAM_MUSIC;
 
         try {
+            // Request exclusive audiofocus to stop any other currently playing app (eg music
+            // player), as we're modifying the volume, and that may make the music very loud.
+            manager.requestAudioFocus(i -> {}, streamType, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE);
             mediaPlayer.setAudioStreamType(streamType);
             mediaPlayer.setOnPreparedListener(mp -> {
                 adjustCurrentVolumeForAlert(streamType, volumeFrac, overrideSilentMode);
@@ -366,6 +369,7 @@ public class AlertPlayer {
                 }
                 mediaPlayer = null;
                 revertCurrentVolume(streamType);
+                manager.abandonAudioFocus(i -> {});
             });
 
             mediaPlayer.prepareAsync();


### PR DESCRIPTION
Tested in emulator (api 24) with music player playing heavy metal in the background. When the alert is triggered (via "test alert"), the music stops.