### PR TITLE
Add specific regional versions of Microtech and Ottai in companion

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/services/UiBasedCollector.java
@@ -103,6 +103,8 @@ public class UiBasedCollector extends NotificationListenerService {
         coOptedPackages.add("com.senseonics.androidapp");
         coOptedPackages.add("com.microtech.aidexx.mgdl");
         coOptedPackages.add("com.ottai.seas"); // Experiment
+        coOptedPackages.add("com.microtech.aidexx"); //for microtech china version
+        coOptedPackages.add("com.ottai.tag"); // //for ottai china version
 
         coOptedPackagesAll.add("com.dexcom.dexcomone");
         coOptedPackagesAll.add("com.dexcom.d1plus");
@@ -113,6 +115,8 @@ public class UiBasedCollector extends NotificationListenerService {
         coOptedPackagesAll.add("com.senseonics.androidapp");
         coOptedPackagesAll.add("com.microtech.aidexx.mgdl");
         coOptedPackagesAll.add("com.ottai.seas"); // Experiment
+        coOptedPackagesAll.add("com.microtech.aidexx"); //for microtech china version
+        coOptedPackagesAll.add("com.ottai.tag"); // //for ottai china version
 
         companionAppIoBPackages.add("com.insulet.myblue.pdm");
 
@@ -328,7 +332,11 @@ public class UiBasedCollector extends NotificationListenerService {
         try {
             val ftext = filterString(text);
             if (Unitized.usingMgDl()) {
-                mgdl = Integer.parseInt(ftext);
+                if(isValidMmol(ftext)){
+                    mgdl = (int) (Double.parseDouble(String.valueOf(ftext)) * 18);
+                }else{
+                    mgdl = Integer.parseInt(String.valueOf(ftext));
+                }
             } else {
                 if (isValidMmol(ftext)) {
                     val result = JoH.tolerantParseDouble(ftext, -1);


### PR DESCRIPTION
1.	Add specific regional versions of Microtech and Ottai in companion mode.
2.	Modify companion mode so that when an xDrip user selects mg/dL as the display unit, if the source reading is in mmol/L, it is multiplied by 18 to convert to mg/dL.

Explanation: In some regions, CGMs are more affordable. Addressing the differences in blood glucose units enables users without insurance to access and use these more affordable CGM options.